### PR TITLE
allow Django versions 1.6 and 1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'Django==1.7',
+        'Django>=1.6.5',
         'djangorestframework==2.4.3',
         'requests>=2.3.0',
     ],


### PR DESCRIPTION
This way, an install won't overwrite Django 1.6.5+ with 1.7.  README.rst says 1.6.5+ and 1.7 are both compatible.

i'd like to recommend a similar less-strict implementation for the djangorestframework requirement, as well.
