### PR TITLE
Makes has_add_permissions compatible with Django 3.0 and above

### DIFF
--- a/authemail/admin.py
+++ b/authemail/admin.py
@@ -12,7 +12,7 @@ class SignupCodeAdmin(admin.ModelAdmin):
     ordering = ('-created_at',)
     readonly_fields = ('user', 'code', 'ipaddr')
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 
@@ -25,7 +25,7 @@ class SignupCodeInline(admin.TabularInline):
     )
     readonly_fields = ('code', 'ipaddr', 'created_at')
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 
@@ -34,7 +34,7 @@ class PasswordResetCodeAdmin(admin.ModelAdmin):
     ordering = ('-created_at',)
     readonly_fields = ('user', 'code')
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 
@@ -47,7 +47,7 @@ class PasswordResetCodeInline(admin.TabularInline):
     )
     readonly_fields = ('code', 'created_at')
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 
@@ -56,7 +56,7 @@ class EmailChangeCodeAdmin(admin.ModelAdmin):
     ordering = ('-created_at',)
     readonly_fields = ('user', 'code', 'email')
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 
@@ -69,7 +69,7 @@ class EmailChangeCodeInline(admin.TabularInline):
     )
     readonly_fields = ('code', 'email', 'created_at')
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 

--- a/authemail/forms.py
+++ b/authemail/forms.py
@@ -4,6 +4,46 @@ from django.contrib.auth.forms import UserChangeForm
 from django.utils.translation import ugettext_lazy as _
 
 
+class EmailUserCreationForm(forms.ModelForm):
+    """
+    A form that creates a user, with no privileges, from the given email and
+    password.
+    """
+    password1 = forms.CharField(label=_('Password'),
+                                widget=forms.PasswordInput)
+    password2 = forms.CharField(label=_('Password confirmation'),
+                                widget=forms.PasswordInput,
+                                help_text=_('Enter the same password as '
+                                            'above, for verification.'))
+
+    class Meta:
+        model = get_user_model()
+        fields = ('email',)
+
+    # def clean_email(self):
+    #     email = self.cleaned_data.get('email')
+    #     try:
+    #         get_user_model().objects.get(email=email)
+    #     except get_user_model().DoesNotExist:
+    #         return email
+    #     raise forms.ValidationError(_('A user with that email already exists.'))
+
+    def clean_password2(self):
+        password1 = self.cleaned_data.get('password1')
+        password2 = self.cleaned_data.get('password2')
+        if password1 and password2 and password1 != password2:
+            raise forms.ValidationError(
+                _('The two password fields did not match.'))
+        return password2
+
+    def save(self, commit=True):
+        user = super(EmailUserCreationForm, self).save(commit=False)
+        user.set_password(self.cleaned_data['password1'])
+        if commit:
+            user.save()
+        return user
+
+
 class EmailUserPasswordResetForm(forms.Form):
     """
     A form that creates a user, with no privileges, from the given email and

--- a/authemail/forms.py
+++ b/authemail/forms.py
@@ -4,7 +4,7 @@ from django.contrib.auth.forms import UserChangeForm
 from django.utils.translation import ugettext_lazy as _
 
 
-class EmailUserCreationForm(forms.ModelForm):
+class EmailUserPasswordResetForm(forms.Form):
     """
     A form that creates a user, with no privileges, from the given email and
     password.
@@ -14,34 +14,16 @@ class EmailUserCreationForm(forms.ModelForm):
     password2 = forms.CharField(label=_('Password confirmation'),
                                 widget=forms.PasswordInput,
                                 help_text=_('Enter the same password as '
-                                'above, for verification.'))
+                                            'above, for verification.'))
+    code = forms.CharField(widget=forms.HiddenInput)
 
-    class Meta:
-        model = get_user_model()
-        fields = ('email',)
-
-    def clean_email(self):
-        email = self.cleaned_data.get('email')
-        try:
-            get_user_model().objects.get(email=email)
-        except get_user_model().DoesNotExist:
-            return email
-        raise forms.ValidationError(_('A user with that email already exists.'))
-
-    def clean_password2(self):
+    def clean(self):
         password1 = self.cleaned_data.get('password1')
         password2 = self.cleaned_data.get('password2')
         if password1 and password2 and password1 != password2:
             raise forms.ValidationError(
                 _('The two password fields did not match.'))
-        return password2
-
-    def save(self, commit=True):
-        user = super(EmailUserCreationForm, self).save(commit=False)
-        user.set_password(self.cleaned_data['password1'])
-        if commit:
-            user.save()
-        return user
+        return self.cleaned_data
 
 
 class EmailUserChangeForm(UserChangeForm):

--- a/authemail/models.py
+++ b/authemail/models.py
@@ -29,7 +29,7 @@ class EmailUserManager(BaseUserManager):
             raise ValueError('Users must have an email address')
         email = self.normalize_email(email)
         user = self.model(email=email,
-                          is_staff=is_staff, is_active=True,
+                          is_staff=is_staff, is_active=False,
                           is_superuser=is_superuser, is_verified=is_verified,
                           last_login=now, date_joined=now, **extra_fields)
         user.set_password(password)
@@ -60,7 +60,7 @@ class EmailAbstractUser(AbstractBaseUser, PermissionsMixin):
         help_text=_('Designates whether the user can log into this '
                     'admin site.'))
     is_active = models.BooleanField(
-        _('active'), default=True,
+        _('active'), default=False,
         help_text=_('Designates whether this user should be treated as '
                     'active.  Unselect this instead of deleting accounts.'))
     date_joined = models.DateTimeField(_('date joined'), default=timezone.now)
@@ -110,6 +110,7 @@ class SignupCodeManager(models.Manager):
         try:
             signup_code = SignupCode.objects.get(code=code)
             signup_code.user.is_verified = True
+            signup_code.user.is_active = True
             signup_code.user.save()
             return True
         except SignupCode.DoesNotExist:

--- a/authemail/templates/authemail/passwordreset_form.html
+++ b/authemail/templates/authemail/passwordreset_form.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+    <meta charset="UTF-8" />
+    <title>Reset password</title>
+</head>
+<body>
+<p>
+Reset password
+    {{ form.media }}
+    {{ form.errors }}
+    <form method="post" class="form">
+        {% csrf_token %}
+    {{ form.as_p }}
+        {% buttons %}
+            <button type="submit" class="btn btn-primary">Submit</button>
+        {% endbuttons %}
+    </form>
+
+</p>
+</body>
+</html>

--- a/authemail/urls.py
+++ b/authemail/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
 
     path('password/reset/', views.PasswordReset.as_view(),
          name='authemail-password-reset'),
+    path('password/reset/form/', views.password_reset_verify, name = "authemail-password-reset-form"),
     path('password/reset/verify/', views.PasswordResetVerify.as_view(),
          name='authemail-password-reset-verify'),
     path('password/reset/verified/', views.PasswordResetVerified.as_view(),


### PR DESCRIPTION
I could not successfully use this without overriding has_object_permissions for all of the class as defined in admin.py. As far as I  understand these functions are now required to support two parameters. This pull request fixes that.