### PR TITLE
Added 'url' context variable for email rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage.xml
 ## Vim files
 .*.swp
 .idea
+env/

--- a/authemail/models.py
+++ b/authemail/models.py
@@ -141,6 +141,8 @@ class EmailChangeCodeManager(models.Manager):
 
 
 def send_multi_format_email(template_prefix, template_ctxt, target_email):
+    url = settings.FRONT_END_URL
+    template_ctxt['url'] = url
     subject_file = 'authemail/%s_subject.txt' % template_prefix
     txt_file = 'authemail/%s.txt' % template_prefix
     html_file = 'authemail/%s.html' % template_prefix

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -147,7 +147,7 @@ EMAIL_HOST_USER = os.environ.get('AUTHEMAIL_EMAIL_HOST_USER') or '<YOUR EMAIL_HO
 EMAIL_HOST_PASSWORD = os.environ.get('AUTHEMAIL_EMAIL_HOST_PASSWORD') or '<YOUR EMAIL_HOST_PASSWORD HERE>'
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
-
+FRONT_END_URL = os.environ.get('AUTHEMAIL_FRONT_END_URL') or "http://localhost:8000"
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 


### PR DESCRIPTION
I have added a new variable to be sent over the email renderer.

Why? Well.
Let's imagine we have multiple environments.
I could not figure out a way to send my front-end's url so the client is sent to the front-end's site and then the front end sends the GET request to the backend in order.