### PR TITLE
Add id field to UserSerializer

### DIFF
--- a/authemail/serializers.py
+++ b/authemail/serializers.py
@@ -44,4 +44,4 @@ class EmailChangeVerifySerializer(serializers.Serializer):
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
-        fields = ('email', 'first_name', 'last_name')
+        fields = ('id', 'email', 'first_name', 'last_name')


### PR DESCRIPTION
As pointed out in https://github.com/celiao/django-rest-authemail/issues/48 the endpoint users/me is not returning the user id, which is needed in order to make other user related requests.

This PR adds that field to the serializer.
