### PR TITLE
updated the depricated version of the function "ugettext_lazy" for ne…

### DIFF
--- a/authemail/models.py
+++ b/authemail/models.py
@@ -7,7 +7,7 @@ from django.core.mail.message import EmailMultiAlternatives
 from django.db import models
 from django.template.loader import render_to_string
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.core.mail import send_mail
 
 # Make part of the model eventually, so it can be edited


### PR DESCRIPTION
…w version, gettext_lazy according to the django documentation

the documentation with the new instructions can be found here: "https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0"
"https://docs.djangoproject.com/en/4.0/topics/i18n/translation/"