### PR TITLE
Add the request to the context for the serializer

### DIFF
--- a/authemail/models.py
+++ b/authemail/models.py
@@ -140,17 +140,17 @@ class EmailChangeCodeManager(models.Manager):
         return EXPIRY_PERIOD
 
 
-def send_multi_format_email(template_prefix, template_ctxt, target_email):
+def send_multi_format_email(request, template_prefix, template_ctxt, target_email):
     subject_file = 'authemail/%s_subject.txt' % template_prefix
     txt_file = 'authemail/%s.txt' % template_prefix
     html_file = 'authemail/%s.html' % template_prefix
 
-    subject = render_to_string(subject_file).strip()
+    subject = render_to_string(subject_file, request=request).strip()
     from_email = settings.EMAIL_FROM
     to = target_email
     bcc_email = settings.EMAIL_BCC
-    text_content = render_to_string(txt_file, template_ctxt)
-    html_content = render_to_string(html_file, template_ctxt)
+    text_content = render_to_string(txt_file, context=template_ctxt, request=request)
+    html_content = render_to_string(html_file, context=template_ctxt, request=request)
     msg = EmailMultiAlternatives(subject, text_content, from_email, [to],
                                  bcc=[bcc_email])
     msg.attach_alternative(html_content, 'text/html')
@@ -165,14 +165,14 @@ class AbstractBaseCode(models.Model):
     class Meta:
         abstract = True
 
-    def send_email(self, prefix):
+    def send_email(self, request, prefix):
         ctxt = {
             'email': self.user.email,
             'first_name': self.user.first_name,
             'last_name': self.user.last_name,
             'code': self.code
         }
-        send_multi_format_email(prefix, ctxt, target_email=self.user.email)
+        send_multi_format_email(request, prefix, ctxt, target_email=self.user.email)
 
     def __str__(self):
         return self.code
@@ -183,17 +183,17 @@ class SignupCode(AbstractBaseCode):
 
     objects = SignupCodeManager()
 
-    def send_signup_email(self):
+    def send_signup_email(self, request):
         prefix = 'signup_email'
-        self.send_email(prefix)
+        self.send_email(request, prefix)
 
 
 class PasswordResetCode(AbstractBaseCode):
     objects = PasswordResetCodeManager()
 
-    def send_password_reset_email(self):
+    def send_password_reset_email(self, request):
         prefix = 'password_reset_email'
-        self.send_email(prefix)
+        self.send_email(request, prefix)
 
 
 class EmailChangeCode(AbstractBaseCode):
@@ -201,9 +201,9 @@ class EmailChangeCode(AbstractBaseCode):
 
     objects = EmailChangeCodeManager()
 
-    def send_email_change_emails(self):
+    def send_email_change_emails(self, request):
         prefix = 'email_change_notify_previous_email'
-        self.send_email(prefix)
+        self.send_email(request, prefix)
 
         prefix = 'email_change_confirm_new_email'
         ctxt = {
@@ -211,4 +211,4 @@ class EmailChangeCode(AbstractBaseCode):
             'code': self.code
         }
 
-        send_multi_format_email(prefix, ctxt, target_email=self.email)
+        send_multi_format_email(request, prefix, ctxt, target_email=self.email)

--- a/authemail/views.py
+++ b/authemail/views.py
@@ -58,7 +58,7 @@ class Signup(APIView):
         user.last_name = last_name
         if not must_validate_email:
             user.is_verified = True
-            send_multi_format_email(request, 'welcome_email',
+            send_multi_format_email('welcome_email',
                                     {'email': user.email, },
                                     target_email=user.email)
         user.save()
@@ -67,7 +67,7 @@ class Signup(APIView):
             # Create and associate signup code
             ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
             signup_code = SignupCode.objects.create_signup_code(user, ipaddr)
-            signup_code.send_signup_email(request)
+            signup_code.send_signup_email()
 
         content = {'email': email, 'first_name': first_name,
                     'last_name': last_name}
@@ -159,16 +159,17 @@ class PasswordReset(APIView):
                 if user.is_verified:
                     password_reset_code = \
                         PasswordResetCode.objects.create_password_reset_code(user)
-                    password_reset_code.send_password_reset_email(request)
+                    password_reset_code.send_password_reset_email()
                 elif not useris_verified and getattr(settings, "AUTH_EMAIL_VERIFICATION", True):
                     # not verified - send the user a verification email instead
                     ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
                     signup_code = SignupCode.objects.create_signup_code(user, ipaddr)
-                    signup_code.send_signup_email(request)
+                    signup_code.send_signup_email()
 
         except get_user_model().DoesNotExist:
             pass
         return Response(content, status=status.HTTP_201_CREATED)
+
 
 class PasswordResetVerify(APIView):
     permission_classes = (AllowAny,)
@@ -254,7 +255,7 @@ class EmailChange(APIView):
             pass
 
         email_change_code = EmailChangeCode.objects.create_email_change_code(user, email_new)
-        email_change_code.send_email_change_emails(request)
+        email_change_code.send_email_change_emails()
 
         content = {'email': email_new}
         return Response(content, status=status.HTTP_201_CREATED)

--- a/authemail/views.py
+++ b/authemail/views.py
@@ -144,7 +144,7 @@ class PasswordReset(APIView):
         if not serializer.is_valid():
             raise exceptions.ValidationError(serializer.errors)
         email = serializer.data['email']
-
+        content = {'email': email}
         try:
             user = get_user_model().objects.get(email=email)
 
@@ -155,15 +155,12 @@ class PasswordReset(APIView):
                 password_reset_code = \
                     PasswordResetCode.objects.create_password_reset_code(user)
                 password_reset_code.send_password_reset_email()
-                content = {'email': email}
-                return Response(content, status=status.HTTP_201_CREATED)
 
         except get_user_model().DoesNotExist:
             pass
 
-        # Since this is AllowAny, don't give away error.
-        raise exceptions.ValidationError(_('Password reset not allowed.'))
-
+        # return a 201 status for any email - we don't want to give away if an email exists or not
+        return Response(content, status=status.HTTP_201_CREATED)
 
 
 class PasswordResetVerify(APIView):

--- a/authemail/views.py
+++ b/authemail/views.py
@@ -4,20 +4,20 @@ from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.utils.translation import gettext as _
 
-from rest_framework import status
+from rest_framework import status, exceptions
 from rest_framework.authtoken.models import Token
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from authemail.models import SignupCode, EmailChangeCode, PasswordResetCode
-from authemail.models import send_multi_format_email
-from authemail.serializers import SignupSerializer, LoginSerializer
-from authemail.serializers import PasswordResetSerializer
-from authemail.serializers import PasswordResetVerifiedSerializer
-from authemail.serializers import EmailChangeSerializer
-from authemail.serializers import PasswordChangeSerializer
-from authemail.serializers import UserSerializer
+from .models import SignupCode, EmailChangeCode, PasswordResetCode
+from .models import send_multi_format_email
+from .serializers import SignupSerializer, LoginSerializer
+from .serializers import PasswordResetSerializer
+from .serializers import PasswordResetVerifiedSerializer
+from .serializers import EmailChangeSerializer
+from .serializers import PasswordChangeSerializer
+from .serializers import UserSerializer
 
 
 class Signup(APIView):
@@ -27,52 +27,51 @@ class Signup(APIView):
     def post(self, request, format=None):
         serializer = self.serializer_class(data=request.data, context={'request': request})
 
-        if serializer.is_valid():
-            email = serializer.data['email']
-            password = serializer.data['password']
-            first_name = serializer.data['first_name']
-            last_name = serializer.data['last_name']
+        if not serializer.is_valid():
+            raise exceptions.ValidationError(serializer.errors)
 
-            must_validate_email = getattr(settings, "AUTH_EMAIL_VERIFICATION", True)
+        email = serializer.data['email']
+        password = serializer.data['password']
+        first_name = serializer.data['first_name']
+        last_name = serializer.data['last_name']
+
+        must_validate_email = getattr(settings, "AUTH_EMAIL_VERIFICATION", True)
+
+        try:
+            user = get_user_model().objects.get(email=email)
+            if user.is_verified:
+                raise exceptions.ValidationError(_('Email address already taken.'))
 
             try:
-                user = get_user_model().objects.get(email=email)
-                if user.is_verified:
-                    content = {'detail': _('Email address already taken.')}
-                    return Response(content, status=status.HTTP_400_BAD_REQUEST)
+                # Delete old signup codes
+                signup_code = SignupCode.objects.get(user=user)
+                signup_code.delete()
+            except SignupCode.DoesNotExist:
+                pass
 
-                try:
-                    # Delete old signup codes
-                    signup_code = SignupCode.objects.get(user=user)
-                    signup_code.delete()
-                except SignupCode.DoesNotExist:
-                    pass
+        except get_user_model().DoesNotExist:
+            user = get_user_model().objects.create_user(email=email)
 
-            except get_user_model().DoesNotExist:
-                user = get_user_model().objects.create_user(email=email)
+        # Set user fields provided
+        user.set_password(password)
+        user.first_name = first_name
+        user.last_name = last_name
+        if not must_validate_email:
+            user.is_verified = True
+            send_multi_format_email('welcome_email',
+                                    {'email': user.email, },
+                                    target_email=user.email)
+        user.save()
 
-            # Set user fields provided
-            user.set_password(password)
-            user.first_name = first_name
-            user.last_name = last_name
-            if not must_validate_email:
-                user.is_verified = True
-                send_multi_format_email('welcome_email',
-                                        {'email': user.email, },
-                                        target_email=user.email)
-            user.save()
+        if must_validate_email:
+            # Create and associate signup code
+            ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
+            signup_code = SignupCode.objects.create_signup_code(user, ipaddr)
+            signup_code.send_signup_email()
 
-            if must_validate_email:
-                # Create and associate signup code
-                ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
-                signup_code = SignupCode.objects.create_signup_code(user, ipaddr)
-                signup_code.send_signup_email()
-
-            content = {'email': email, 'first_name': first_name,
-                       'last_name': last_name}
-            return Response(content, status=status.HTTP_201_CREATED)
-
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        content = {'email': email, 'first_name': first_name,
+                    'last_name': last_name}
+        return Response(content, status=status.HTTP_201_CREATED)
 
 
 class SignupVerify(APIView):
@@ -91,8 +90,7 @@ class SignupVerify(APIView):
             content = {'success': _('Email address verified.')}
             return Response(content, status=status.HTTP_200_OK)
         else:
-            content = {'detail': _('Unable to verify user.')}
-            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+            raise exceptions.ValidationError(_('Unable to verify user.'))
 
 
 class Login(APIView):
@@ -102,33 +100,26 @@ class Login(APIView):
     def post(self, request, format=None):
         serializer = self.serializer_class(data=request.data, context={'request': request})
 
-        if serializer.is_valid():
-            email = serializer.data['email']
-            password = serializer.data['password']
-            user = authenticate(email=email, password=password)
+        if not serializer.is_valid():
+            raise exceptions.ValidationError(serializer.errors)
 
-            if user:
-                if user.is_verified:
-                    if user.is_active:
-                        token, created = Token.objects.get_or_create(user=user)
-                        return Response({'token': token.key},
-                                        status=status.HTTP_200_OK)
-                    else:
-                        content = {'detail': _('User account not active.')}
-                        return Response(content,
-                                        status=status.HTTP_401_UNAUTHORIZED)
-                else:
-                    content = {'detail':
-                               _('User account not verified.')}
-                    return Response(content, status=status.HTTP_401_UNAUTHORIZED)
-            else:
-                content = {'detail':
-                           _('Unable to login with provided credentials.')}
-                return Response(content, status=status.HTTP_401_UNAUTHORIZED)
+        email = serializer.data['email']
+        password = serializer.data['password']
+        user = authenticate(email=email, password=password)
 
-        else:
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)
+        if not user:
+            raise exceptions.AuthenticationFailed(_('Unable to login with provided credentials.'))
+        
+        if not user.is_verified:
+            raise exceptions.AuthenticationFailed(_('User account not verified.'))
+        
+        if not user.is_active:
+            raise exceptions.ValidationError(_('User account not active.'))
+
+        token, created = Token.objects.get_or_create(user=user)
+        return Response({'token': token.key},
+                        status=status.HTTP_200_OK)
+                
 
 
 class Logout(APIView):
@@ -138,9 +129,7 @@ class Logout(APIView):
         """
         Remove all auth tokens owned by request.user.
         """
-        tokens = Token.objects.filter(user=request.user)
-        for token in tokens:
-            token.delete()
+        tokens = Token.objects.filter(user=request.user).delete()
         content = {'success': _('User logged out.')}
         return Response(content, status=status.HTTP_200_OK)
 
@@ -152,32 +141,29 @@ class PasswordReset(APIView):
     def post(self, request, format=None):
         serializer = self.serializer_class(data=request.data, context={'request': request})
 
-        if serializer.is_valid():
-            email = serializer.data['email']
+        if not serializer.is_valid():
+            raise exceptions.ValidationError(serializer.errors)
+        email = serializer.data['email']
 
-            try:
-                user = get_user_model().objects.get(email=email)
+        try:
+            user = get_user_model().objects.get(email=email)
 
-                # Delete all unused password reset codes
-                PasswordResetCode.objects.filter(user=user).delete()
+            # Delete all unused password reset codes
+            PasswordResetCode.objects.filter(user=user).delete()
 
-                if user.is_verified and user.is_active:
-                    password_reset_code = \
-                        PasswordResetCode.objects.create_password_reset_code(user)
-                    password_reset_code.send_password_reset_email()
-                    content = {'email': email}
-                    return Response(content, status=status.HTTP_201_CREATED)
+            if user.is_verified and user.is_active:
+                password_reset_code = \
+                    PasswordResetCode.objects.create_password_reset_code(user)
+                password_reset_code.send_password_reset_email()
+                content = {'email': email}
+                return Response(content, status=status.HTTP_201_CREATED)
 
-            except get_user_model().DoesNotExist:
-                pass
+        except get_user_model().DoesNotExist:
+            pass
 
-            # Since this is AllowAny, don't give away error.
-            content = {'detail': _('Password reset not allowed.')}
-            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+        # Since this is AllowAny, don't give away error.
+        raise exceptions.ValidationError(_('Password reset not allowed.'))
 
-        else:
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)
 
 
 class PasswordResetVerify(APIView):
@@ -198,8 +184,9 @@ class PasswordResetVerify(APIView):
             content = {'success': _('Email address verified.')}
             return Response(content, status=status.HTTP_200_OK)
         except PasswordResetCode.DoesNotExist:
-            content = {'detail': _('Unable to verify user.')}
-            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+            pass
+
+        raise exceptions.ValidationError(_('Unale to verify user.'))
 
 
 class PasswordResetVerified(APIView):
@@ -209,27 +196,26 @@ class PasswordResetVerified(APIView):
     def post(self, request, format=None):
         serializer = self.serializer_class(data=request.data, context={'request': request})
 
-        if serializer.is_valid():
-            code = serializer.data['code']
-            password = serializer.data['password']
+        if not serializer.is_valid():
+            raise exceptions.ValidationError(serializer.errors)
+    
+        code = serializer.data['code']
+        password = serializer.data['password']
 
-            try:
-                password_reset_code = PasswordResetCode.objects.get(code=code)
-                password_reset_code.user.set_password(password)
-                password_reset_code.user.save()
+        try:
+            password_reset_code = PasswordResetCode.objects.get(code=code)
+            password_reset_code.user.set_password(password)
+            password_reset_code.user.save()
 
-                # Delete password reset code just used
-                password_reset_code.delete()
+            # Delete password reset code just used
+            password_reset_code.delete()
 
-                content = {'success': _('Password reset.')}
-                return Response(content, status=status.HTTP_200_OK)
-            except PasswordResetCode.DoesNotExist:
-                content = {'detail': _('Unable to verify user.')}
-                return Response(content, status=status.HTTP_400_BAD_REQUEST)
+            content = {'success': _('Password reset.')}
+            return Response(content, status=status.HTTP_200_OK)
+        except PasswordResetCode.DoesNotExist:
+            pass
 
-        else:
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)
+        raise exceptions.ValidationError(_('Unable to verify user.'))
 
 
 class EmailChange(APIView):
@@ -239,35 +225,33 @@ class EmailChange(APIView):
     def post(self, request, format=None):
         serializer = self.serializer_class(data=request.data, context={'request': request})
 
-        if serializer.is_valid():
-            user = request.user
+        if not serializer.is_valid():
+            raise exceptions.ValidationError(serializer.errors)
 
-            # Delete all unused email change codes
-            EmailChangeCode.objects.filter(user=user).delete()
+        user = request.user
 
-            email_new = serializer.data['email']
+        # Delete all unused email change codes
+        EmailChangeCode.objects.filter(user=user).delete()
 
-            try:
-                user_with_email = get_user_model().objects.get(email=email_new)
-                if user_with_email.is_verified:
-                    content = {'detail': _('Email address already taken.')}
-                    return Response(content, status=status.HTTP_400_BAD_REQUEST)
-                else:
-                    # If the account with this email address is not verified,
-                    # give this user a chance to verify and grab this email address
-                    raise get_user_model().DoesNotExist
+        email_new = serializer.data['email']
 
-            except get_user_model().DoesNotExist:
-                email_change_code = EmailChangeCode.objects.create_email_change_code(user, email_new)
+        try:
+            user_with_email = get_user_model().objects.get(email=email_new)
+            if user_with_email.is_verified:
+                raise exceptions.ValidationError(_('Email address already in use.'))
+            else:
+                # If the account with this email address is not verified,
+                # give this user a chance to verify and grab this email address
+                raise get_user_model().DoesNotExist
 
-                email_change_code.send_email_change_emails()
+        except get_user_model().DoesNotExist:
+            pass
 
-                content = {'email': email_new}
-                return Response(content, status=status.HTTP_201_CREATED)
+        email_change_code = EmailChangeCode.objects.create_email_change_code(user, email_new)
+        email_change_code.send_email_change_emails()
 
-        else:
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)
+        content = {'email': email_new}
+        return Response(content, status=status.HTTP_201_CREATED)
 
 
 class EmailChangeVerify(APIView):
@@ -286,35 +270,34 @@ class EmailChangeVerify(APIView):
                 email_change_code.delete()
                 raise EmailChangeCode.DoesNotExist()
 
-            # Check if the email address is being used by a verified user.
-            try:
-                user_with_email = get_user_model().objects.get(email=email_change_code.email)
-                if user_with_email.is_verified:
-                    # Delete email change code since won't be used
-                    email_change_code.delete()
-
-                    content = {'detail': _('Email address already taken.')}
-                    return Response(content, status=status.HTTP_400_BAD_REQUEST)
-                else:
-                    # If the account with this email address is not verified,
-                    # delete the account (and signup code) because the email
-                    # address will be used for the user who just verified.
-                    user_with_email.delete()
-            except get_user_model().DoesNotExist:
-                pass
-
-            # If all is well, change the email address.
-            email_change_code.user.email = email_change_code.email
-            email_change_code.user.save()
-
-            # Delete email change code just used
-            email_change_code.delete()
-
-            content = {'success': _('Email address changed.')}
-            return Response(content, status=status.HTTP_200_OK)
         except EmailChangeCode.DoesNotExist:
-            content = {'detail': _('Unable to verify user.')}
-            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+            # email change code doesn't exist or has expired
+            raise exceptions.ValidationError(_('Unable to verify user.'))
+
+        # Check if the email address is already being used by a verified user.
+        try:
+            user_with_email = get_user_model().objects.get(email=email_change_code.email)
+            if user_with_email.is_verified:
+                # Delete email change code since won't be used
+                email_change_code.delete()
+                raise exceptions.ValidationError(_('Email address already taken.'))
+
+            # If the account with this email address is not verified,
+            # delete the account (and signup code) because the email
+            # address will be used for the user who just verified.
+            user_with_email.delete()
+        except get_user_model().DoesNotExist:
+            pass
+
+        # If all is well, change the email address.
+        email_change_code.user.email = email_change_code.email
+        email_change_code.user.save()
+
+        # Delete email change code just used
+        email_change_code.delete()
+
+        content = {'success': _('Email address changed.')}
+        return Response(content, status=status.HTTP_200_OK)
 
 
 class PasswordChange(APIView):
@@ -324,19 +307,17 @@ class PasswordChange(APIView):
     def post(self, request, format=None):
         serializer = self.serializer_class(data=request.data, context={'request': request})
 
-        if serializer.is_valid():
-            user = request.user
+        if not serializer.is_valid():
+            raise exceptions.ValidationError(serializer.errors)
 
-            password = serializer.data['password']
-            user.set_password(password)
-            user.save()
+        user = request.user
 
-            content = {'success': _('Password changed.')}
-            return Response(content, status=status.HTTP_200_OK)
+        password = serializer.data['password']
+        user.set_password(password)
+        user.save()
 
-        else:
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)
+        content = {'success': _('Password changed.')}
+        return Response(content, status=status.HTTP_200_OK)
 
 
 class UserMe(APIView):

--- a/authemail/views.py
+++ b/authemail/views.py
@@ -19,6 +19,13 @@ from .serializers import EmailChangeSerializer
 from .serializers import PasswordChangeSerializer
 from .serializers import UserSerializer
 
+def get_remote_addr(request):
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(',')[0]
+    else:
+        ip = request.META.get('REMOTE_ADDR')
+    return ip or "0.0.0.0"
 
 class Signup(APIView):
     permission_classes = (AllowAny,)
@@ -65,7 +72,7 @@ class Signup(APIView):
 
         if must_validate_email:
             # Create and associate signup code
-            ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
+            ipaddr = get_remote_addr(self.request)
             signup_code = SignupCode.objects.create_signup_code(user, ipaddr)
             signup_code.send_signup_email()
 
@@ -162,7 +169,7 @@ class PasswordReset(APIView):
                     password_reset_code.send_password_reset_email()
                 elif not user.is_verified and getattr(settings, "AUTH_EMAIL_VERIFICATION", True):
                     # not verified - send the user a verification email instead
-                    ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
+                    ipaddr = get_remote_addr(self.request)
                     signup_code = SignupCode.objects.create_signup_code(user, ipaddr)
                     signup_code.send_signup_email()
 

--- a/authemail/views.py
+++ b/authemail/views.py
@@ -58,7 +58,7 @@ class Signup(APIView):
         user.last_name = last_name
         if not must_validate_email:
             user.is_verified = True
-            send_multi_format_email('welcome_email',
+            send_multi_format_email(request, 'welcome_email',
                                     {'email': user.email, },
                                     target_email=user.email)
         user.save()
@@ -67,7 +67,7 @@ class Signup(APIView):
             # Create and associate signup code
             ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
             signup_code = SignupCode.objects.create_signup_code(user, ipaddr)
-            signup_code.send_signup_email()
+            signup_code.send_signup_email(request)
 
         content = {'email': email, 'first_name': first_name,
                     'last_name': last_name}
@@ -159,17 +159,16 @@ class PasswordReset(APIView):
                 if user.is_verified:
                     password_reset_code = \
                         PasswordResetCode.objects.create_password_reset_code(user)
-                    password_reset_code.send_password_reset_email()
+                    password_reset_code.send_password_reset_email(request)
                 elif not useris_verified and getattr(settings, "AUTH_EMAIL_VERIFICATION", True):
                     # not verified - send the user a verification email instead
                     ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
                     signup_code = SignupCode.objects.create_signup_code(user, ipaddr)
-                    signup_code.send_signup_email()
+                    signup_code.send_signup_email(request)
 
         except get_user_model().DoesNotExist:
             pass
         return Response(content, status=status.HTTP_201_CREATED)
-
 
 class PasswordResetVerify(APIView):
     permission_classes = (AllowAny,)
@@ -255,7 +254,7 @@ class EmailChange(APIView):
             pass
 
         email_change_code = EmailChangeCode.objects.create_email_change_code(user, email_new)
-        email_change_code.send_email_change_emails()
+        email_change_code.send_email_change_emails(request)
 
         content = {'email': email_new}
         return Response(content, status=status.HTTP_201_CREATED)

--- a/authemail/views.py
+++ b/authemail/views.py
@@ -160,7 +160,7 @@ class PasswordReset(APIView):
                     password_reset_code = \
                         PasswordResetCode.objects.create_password_reset_code(user)
                     password_reset_code.send_password_reset_email()
-                elif not useris_verified and getattr(settings, "AUTH_EMAIL_VERIFICATION", True):
+                elif not user.is_verified and getattr(settings, "AUTH_EMAIL_VERIFICATION", True):
                     # not verified - send the user a verification email instead
                     ipaddr = self.request.META.get('REMOTE_ADDR', '0.0.0.0')
                     signup_code = SignupCode.objects.create_signup_code(user, ipaddr)

--- a/authemail/views.py
+++ b/authemail/views.py
@@ -25,7 +25,7 @@ class Signup(APIView):
     serializer_class = SignupSerializer
 
     def post(self, request, format=None):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(data=request.data, context={'request': request})
 
         if serializer.is_valid():
             email = serializer.data['email']
@@ -100,7 +100,7 @@ class Login(APIView):
     serializer_class = LoginSerializer
 
     def post(self, request, format=None):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(data=request.data, context={'request': request})
 
         if serializer.is_valid():
             email = serializer.data['email']
@@ -150,7 +150,7 @@ class PasswordReset(APIView):
     serializer_class = PasswordResetSerializer
 
     def post(self, request, format=None):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(data=request.data, context={'request': request})
 
         if serializer.is_valid():
             email = serializer.data['email']
@@ -207,7 +207,7 @@ class PasswordResetVerified(APIView):
     serializer_class = PasswordResetVerifiedSerializer
 
     def post(self, request, format=None):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(data=request.data, context={'request': request})
 
         if serializer.is_valid():
             code = serializer.data['code']
@@ -237,7 +237,7 @@ class EmailChange(APIView):
     serializer_class = EmailChangeSerializer
 
     def post(self, request, format=None):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(data=request.data, context={'request': request})
 
         if serializer.is_valid():
             user = request.user
@@ -322,7 +322,7 @@ class PasswordChange(APIView):
     serializer_class = PasswordChangeSerializer
 
     def post(self, request, format=None):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(data=request.data, context={'request': request})
 
         if serializer.is_valid():
             user = request.user
@@ -344,4 +344,4 @@ class UserMe(APIView):
     serializer_class = UserSerializer
 
     def get(self, request, format=None):
-        return Response(self.serializer_class(request.user).data)
+        return Response(self.serializer_class(request.user, context={'request': request}).data)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='django-rest-authemail',
-    version='2.1.4',
+    version='2.1.5',
     author='Celia Oakley',
     author_email='celia.oakley@alumni.stanford.edu',
     description='A RESTful API for user signup and authentication using email addresses',


### PR DESCRIPTION
This is useful if subclassing the views and using custom serializers.

Use case: User Signups is restricted to administrator users only. I set up a custom SignupSerializer that needs to validate the email address to make sure the domain matches the current user - the current user needs to be found from request.user

E.g.:
```python
def email_domain(email):
    # return email domain of 'email' - example.com

class EmailSignupSerializer(SignupSerializer):
    def validate_email(self, value):
        if email_domain(value) != email_domain(self.context['request'].user.email):
                raise serializers.ValidationError("You may only add users with from the same email domain as yours')
        return value
```