### PR TITLE
Solve ipware dependency issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Django>=2.2.8',
         'djangorestframework>=3.11.0',
         'requests>=2.3.0',
+        'django-ipware>=4.0.2',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='django-rest-authemail',
-    version='2.1.6',
+    version='2.1.7',
     author='Celia Oakley',
     author_email='celia.oakley@alumni.stanford.edu',
     description='A RESTful API for user signup and authentication using email addresses',


### PR DESCRIPTION
Since ipware is called in 'views.py', and it is not a standard library, it should be added in the setup. Users may not add ipware by themselves, and it will create an error.  